### PR TITLE
Fix footnote scrolling

### DIFF
--- a/web/components/content-viewer.js
+++ b/web/components/content-viewer.js
@@ -459,23 +459,31 @@ export class ContentViewer extends LitElement {
     this.originalBodyPosition = '';
     this.originalBodyTop = '';
     this.originalScrollY = 0;
+    this.boundFootnoteHandler = this.handleFootnoteClick.bind(this);
   }
 
   connectedCallback() {
     super.connectedCallback();
-    this.addEventListener('click', this.handleFootnoteClick.bind(this));
+    if (this.shadowRoot) {
+      this.shadowRoot.addEventListener('click', this.boundFootnoteHandler);
+    }
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
+    if (this.shadowRoot) {
+      this.shadowRoot.removeEventListener('click', this.boundFootnoteHandler);
+    }
     // 컴포넌트 제거 시 바깥 스크롤 복원
     this.enableBodyScroll();
   }
 
   handleFootnoteClick(e) {
-    if (e.target.classList.contains('footnote-ref')) {
+    const path = e.composedPath();
+    const link = path.find(el => el.classList && el.classList.contains('footnote-ref'));
+    if (link) {
       e.preventDefault();
-      const href = e.target.getAttribute('href');
+      const href = link.getAttribute('href');
       if (href && href.startsWith('#footnote-')) {
         const targetId = href.substring(1);
         const targetElement = this.shadowRoot.getElementById(targetId);


### PR DESCRIPTION
## Summary
- make footnote links work inside the shadow DOM

## Testing
- `go test ./...` *(fails: HTTP 503)*
- `npm test` in `functions` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688c21e6a4d8832b81fb9b729ee08818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of footnote click handling, ensuring clicks on nested elements within footnote links are properly detected and processed.
  * Enhanced event listener management for better performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->