### PR TITLE
Escape quotes in footnote titles

### DIFF
--- a/web/components/content-viewer.js
+++ b/web/components/content-viewer.js
@@ -625,7 +625,9 @@ export class ContentViewer extends LitElement {
   escapeHtml(text) {
     const div = document.createElement('div');
     div.textContent = text;
-    return div.innerHTML;
+    return div.innerHTML
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
   }
 
   showPrompt() {


### PR DESCRIPTION
## Summary
- escape quotes in footnote references to prevent malformed attributes

## Testing
- `go test ./...`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688eb9f82e48832b9e07d6a3aa08c07e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML escaping to better handle double and single quote characters, enhancing content security and display accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->