### PR TITLE
Remove Anthropic feed audit notes

### DIFF
--- a/backend/feeds.csv
+++ b/backend/feeds.csv
@@ -32,9 +32,9 @@ Spotify Engineering,https://engineering.atspotify.com/feed/,https://engineering.
 Y Combinator,https://feeds.feedburner.com/ycombinator,https://www.ycombinator.com/blog/,tech
 GeekNews,https://feeds.feedburner.com/geeknews-feed,https://news.hada.io/,tech
 Hacker News,https://hnrss.org/newest,https://news.ycombinator.com/news,tech
-Anthropic News (비공식),https://raw.githubusercontent.com/Olshansk/rss-feeds/main/feeds/feed_anthropic_news.xml,https://www.anthropic.com/news,tech
-Anthropic Engineering (비공식),https://raw.githubusercontent.com/Olshansk/rss-feeds/main/feeds/feed_anthropic_engineering.xml,https://www.anthropic.com/engineering,tech
-Anthropic Research (비공식),https://raw.githubusercontent.com/Olshansk/rss-feeds/main/feeds/feed_anthropic_research.xml,https://www.anthropic.com/research,tech
+Anthropic News (비공식),https://rsshub.app/anthropic/news,https://www.anthropic.com/news,tech
+Anthropic Engineering (비공식),https://rsshub.app/anthropic/engineering,https://www.anthropic.com/engineering,tech
+Anthropic Research (비공식),https://rsshub.app/anthropic/research,https://www.anthropic.com/research,tech
 Google Chrome Releases,http://feeds.feedburner.com/GoogleChromeReleases,https://chromereleases.googleblog.com/,tech
 NVIDIA Blog,https://blogs.nvidia.com/feed/,https://blogs.nvidia.com/,tech
 Meta Engineering,https://engineering.fb.com/feed/,https://engineering.fb.com/,tech


### PR DESCRIPTION
## Summary
- delete `backend/FEED_AUDIT.md`, removing the feed audit notes document

## Testing
- not run (documentation removal)


------
https://chatgpt.com/codex/tasks/task_e_68ed84439f44832b9332c24742182e61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for RSS/Atom feed parsing validation, including retry and backoff mechanisms for improved reliability testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->