### PR TITLE
Switch default Gemini model to 3 pro preview

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -63,7 +63,7 @@ Environment variables:
 
 Command-line flags:
 - `--feeds`: CSV file path (default: `feeds.csv`)
-- `--model`: Gemini model (default: `gemini-2.5-pro`)
+- `--model`: Gemini model (default: `gemini-3-pro-preview`)
 - `--cutoff`: Hours to look back (default: 24)
 - `--timeout`: HTTP timeout seconds (default: 15)
 - `--preset`: Summary style (default: `general`), available: `general`, `community`

--- a/backend/cmd/generate/main.go
+++ b/backend/cmd/generate/main.go
@@ -63,8 +63,8 @@ func main() {
 	for _, preset := range presets {
 		fmt.Printf("프리셋 '%s' 처리 중...\n", preset)
 
-// 기존 daily-feed 앱 생성 및 실행
-dailyApp, err := app.New("feeds.csv", "gemini-3-pro-preview", 24, 15, preset, false)
+		// 기존 daily-feed 앱 생성 및 실행
+		dailyApp, err := app.New("feeds.csv", "gemini-3-pro-preview", 24, 15, preset, false)
 		if err != nil {
 			fmt.Printf("앱 생성 실패 (%s): %v\n", preset, err)
 			continue

--- a/backend/cmd/generate/main.go
+++ b/backend/cmd/generate/main.go
@@ -63,8 +63,8 @@ func main() {
 	for _, preset := range presets {
 		fmt.Printf("프리셋 '%s' 처리 중...\n", preset)
 
-		// 기존 daily-feed 앱 생성 및 실행
-		dailyApp, err := app.New("feeds.csv", "gemini-2.5-pro", 24, 15, preset, false)
+// 기존 daily-feed 앱 생성 및 실행
+dailyApp, err := app.New("feeds.csv", "gemini-3-pro-preview", 24, 15, preset, false)
 		if err != nil {
 			fmt.Printf("앱 생성 실패 (%s): %v\n", preset, err)
 			continue

--- a/backend/main.go
+++ b/backend/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	// 플래그 정의
 	feedsFile := flag.String("feeds", "feeds.csv", "RSS 피드 목록 파일 경로")
-	geminiModel := flag.String("model", "gemini-2.5-pro", "Gemini 모델명")
+geminiModel := flag.String("model", "gemini-3-pro-preview", "Gemini 모델명")
 	cutoffHours := flag.Int("cutoff", 24, "피드 수집 시간 범위 (시간)")
 	httpTimeout := flag.Int("timeout", 15, "HTTP 요청 타임아웃 (초)")
 	summaryPreset := flag.String("preset", "general", "요약 프리셋 (general, casual)")

--- a/backend/main.go
+++ b/backend/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	// 플래그 정의
 	feedsFile := flag.String("feeds", "feeds.csv", "RSS 피드 목록 파일 경로")
-geminiModel := flag.String("model", "gemini-3-pro-preview", "Gemini 모델명")
+	geminiModel := flag.String("model", "gemini-3-pro-preview", "Gemini 모델명")
 	cutoffHours := flag.Int("cutoff", 24, "피드 수집 시간 범위 (시간)")
 	httpTimeout := flag.Int("timeout", 15, "HTTP 요청 타임아웃 (초)")
 	summaryPreset := flag.String("preset", "general", "요약 프리셋 (general, casual)")


### PR DESCRIPTION
## Summary
- set the default Gemini model flag and generator script to `gemini-3-pro-preview`
- update developer documentation to mention the new default model name

## Testing
- go test ./... *(hangs in this environment; aborted after waiting)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d17afbe44832bb148d375a8812465)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default AI model across backend services to a newer version, ensuring the system uses the latest available model for content generation and related features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->