### PR TITLE
Use magazine preset as sole summary option

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ go run cmd/fcm-send/main.go -topic "daily-feed" -title "테스트" -body "테스
 
 # CLI 도구 빌드 및 실행
 go build -o daily-feed
-./daily-feed --preset developer --feeds feeds.csv
+./daily-feed --preset magazine --feeds feeds.csv
 ```
 
 ### 웹 UI
@@ -192,7 +192,7 @@ firebase deploy --only functions
 ```json
 {
   "date": "2025-01-15",
-  "preset": "developer", 
+  "preset": "magazine",
   "summary": "마크다운 형식의 AI 요약...",
   "prompt": {
     "system": "시스템 프롬프트...",

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -10,15 +10,15 @@ go run .
 go build -o daily-feed .
 
 # Run with custom options
-go run . --preset developer --feeds feeds.csv --cutoff 24 --timeout 15
+go run . --preset magazine --feeds feeds.csv --cutoff 24 --timeout 15
 
 # Run tests
 go test ./...
 go test ./pkg/feed/       # Run feed package tests specifically
 
 # Development with specific presets
-go run . --preset general | pbcopy       # Copy output to clipboard (macOS)
-go run . --preset community > output.md  # Save to file
+go run . --preset magazine | pbcopy       # Copy output to clipboard (macOS)
+go run . --preset magazine > output.md    # Save to file
 
 # FCM push notifications
 go run cmd/fcm-send/main.go --token "FCM_TOKEN" --title "Test" --body "Hello"
@@ -50,7 +50,7 @@ Daily Feed is a Go-based RSS/Atom feed aggregator with AI-powered summarization:
 ### Key Features
 
 - **Multi-format support**: RSS 2.0 and Atom 1.0 feeds
-- **2 summary presets**: `general`, `community`
+- **단일 요약 프리셋**: `magazine`
 - **Robust error handling**: Custom error types with wrapping
 - **Concurrent processing**: Goroutines for feed fetching
 - **XML entity fixing**: Handles malformed XML entities
@@ -66,7 +66,7 @@ Command-line flags:
 - `--model`: Gemini model (default: `gemini-3-pro-preview`)
 - `--cutoff`: Hours to look back (default: 24)
 - `--timeout`: HTTP timeout seconds (default: 15)
-- `--preset`: Summary style (default: `general`), available: `general`, `community`
+- `--preset`: Summary style (default: `magazine`), available: `magazine`
 
 ## Testing
 

--- a/backend/cmd/generate/main.go
+++ b/backend/cmd/generate/main.go
@@ -47,8 +47,8 @@ func main() {
 	// 오늘 날짜 (한국 시간 기준)
 	today := time.Now().In(kst).Format("2006-01-02")
 
-	// 2가지 프리셋
-	presets := []string{"general", "casual"}
+	// 매거진 프리셋만 사용
+	presets := []string{"magazine"}
 
 	// 출력 디렉토리 생성 (web/data/summaries)
 	outputDir := filepath.Join("..", "web", "data", "summaries", today)

--- a/backend/main.go
+++ b/backend/main.go
@@ -17,7 +17,7 @@ func main() {
 	geminiModel := flag.String("model", "gemini-3-pro-preview", "Gemini 모델명")
 	cutoffHours := flag.Int("cutoff", 24, "피드 수집 시간 범위 (시간)")
 	httpTimeout := flag.Int("timeout", 15, "HTTP 요청 타임아웃 (초)")
-	summaryPreset := flag.String("preset", "general", "요약 프리셋 (general, casual)")
+	summaryPreset := flag.String("preset", "magazine", "요약 프리셋 (magazine)")
 	debug := flag.Bool("debug", false, "디버그 모드 활성화 (Gemini API 파라미터 로그 출력)")
 	flag.Parse()
 

--- a/backend/pkg/config/config.go
+++ b/backend/pkg/config/config.go
@@ -31,7 +31,7 @@ func (c *Config) Validate() error {
 	if c.SummaryPreset == "" {
 		return fmt.Errorf("summary_preset이 설정되지 않았습니다")
 	}
-	validPresets := []string{"general", "casual"}
+	validPresets := []string{"magazine"}
 	isValid := false
 	for _, preset := range validPresets {
 		if c.SummaryPreset == preset {

--- a/web/components/content-viewer.js
+++ b/web/components/content-viewer.js
@@ -453,7 +453,7 @@ export class ContentViewer extends LitElement {
   constructor() {
     super();
     this.data = {};
-    this.preset = 'general';
+    this.preset = 'magazine';
     this.showPromptModal = false;
     this.originalBodyOverflow = '';
     this.originalBodyPosition = '';
@@ -526,11 +526,7 @@ export class ContentViewer extends LitElement {
     }
 
     const presetLabels = {
-      'general': '📰 뉴스',
-      'casual': '💬 캐주얼',
-      'community': '🏠 커뮤니티',
-      'default': '🔍 기본',
-      'developer': '👨‍💻 개발자'
+      'magazine': '📰 매거진'
     };
 
     return html`

--- a/web/components/daily-feed-app.js
+++ b/web/components/daily-feed-app.js
@@ -442,8 +442,8 @@ export class DailyFeedApp extends LitElement {
 
   loadPresetFromStorage() {
     try {
-      const savedPreset = localStorage.getItem('daily-feed-preset');
-      const validPresets = ['general', 'casual', 'community', 'default', 'developer'];
+    const savedPreset = localStorage.getItem('daily-feed-preset');
+    const validPresets = ['magazine'];
       
       if (savedPreset && validPresets.includes(savedPreset)) {
         return savedPreset;
@@ -452,7 +452,7 @@ export class DailyFeedApp extends LitElement {
       console.warn('프리셋 로드 실패:', error);
     }
     
-    return 'general'; // 기본값
+    return 'magazine'; // 기본값
   }
 
   savePresetToStorage(preset) {
@@ -485,7 +485,7 @@ export class DailyFeedApp extends LitElement {
       return;
     }
     
-    this.availablePresets = this.indexData[this.selectedDate].presets || [];
+    this.availablePresets = (this.indexData[this.selectedDate].presets || []).filter(preset => preset === 'magazine');
     
     // 현재 선택된 프리셋이 사용 가능한 목록에 없으면 첫 번째 프리셋으로 변경
     if (this.availablePresets.length > 0 && !this.availablePresets.includes(this.currentPreset)) {
@@ -576,7 +576,7 @@ export class DailyFeedApp extends LitElement {
       this.showLoading('데이터를 불러오는 중...');
       
       const basePath = this.getBasePath();
-      const presets = this.availablePresets || ['general'];
+    const presets = this.availablePresets && this.availablePresets.length > 0 ? this.availablePresets : ['magazine'];
       const newData = { date: this.selectedDate, summaries: {} };
       
       const promises = presets.map(async preset => {

--- a/web/components/preset-tabs.js
+++ b/web/components/preset-tabs.js
@@ -57,7 +57,7 @@ export class PresetTabs extends LitElement {
 
   constructor() {
     super();
-    this.currentPreset = 'general';
+    this.currentPreset = 'magazine';
     this.availablePresets = [];
   }
 
@@ -89,11 +89,7 @@ export class PresetTabs extends LitElement {
 
   getPresetLabels() {
     return {
-      'general': '📰 뉴스',
-      'casual': '💬 캐주얼',
-      'community': '🏠 커뮤니티',
-      'default': '🔍 기본',
-      'developer': '👨‍💻 개발자'
+      'magazine': '📰 매거진'
     };
   }
 


### PR DESCRIPTION
## Summary
- limit backend configuration and generator to the single `magazine` preset and update CLI/documentation references
- adjust web UI preset defaults, labels, and filtering to reflect only the magazine preset

## Testing
- go test ./... (hangs, interrupted)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69231757b2dc832bbd5691e9fd49fe16)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Consolidated preset options to magazine-only; default preset changed from general to magazine throughout the application
  * Updated documentation and CLI examples to reflect the updated preset configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->