### PR TITLE
Adjust markdown table and blockquote colors for dark mode

### DIFF
--- a/web/components/content-viewer.js
+++ b/web/components/content-viewer.js
@@ -293,9 +293,9 @@ export class ContentViewer extends LitElement {
     .markdown-content blockquote {
       padding: 16px 20px;
       margin-bottom: 24px;
-      color: #4a5568;
-      border-left: 4px solid #4299e1;
-      background-color: #f7fafc;
+      color: var(--blockquote-text);
+      border-left: 4px solid var(--blockquote-border);
+      background-color: var(--blockquote-bg);
       border-radius: 0 8px 8px 0;
       font-size: 16px;
       line-height: 1.8;
@@ -350,16 +350,17 @@ export class ContentViewer extends LitElement {
     .markdown-content table th,
     .markdown-content table td {
       padding: 6px 13px;
-      border: 1px solid #d0d7de;
+      border: 1px solid var(--table-border);
+      color: var(--text-primary);
     }
 
     .markdown-content table th {
       font-weight: 600;
-      background-color: #f6f8fa;
+      background-color: var(--table-header-bg);
     }
 
     .markdown-content table tr:nth-child(even) {
-      background-color: #f6f8fa;
+      background-color: var(--table-row-alt-bg);
     }
 
     .markdown-content hr {

--- a/web/index.html
+++ b/web/index.html
@@ -41,7 +41,7 @@
         // 인용문법 렌더러 설정
         const renderer = new marked.Renderer();
         renderer.blockquote = function(quote) {
-            return '<blockquote style="border-left: 3px solid #d1d9e0; padding-left: 16px; margin-left: 0; color: #57606a; font-style: italic;">' + quote + '</blockquote>';
+            return `<blockquote class="markdown-blockquote">${quote}</blockquote>`;
         };
         marked.setOptions({ renderer: renderer });
     </script>
@@ -71,6 +71,12 @@
             --status-offline-bg: #fff3cd;
             --status-offline-border: #ffeaa7;
             --status-offline-text: #856404;
+            --blockquote-bg: #f7fafc;
+            --blockquote-border: #4299e1;
+            --blockquote-text: #4a5568;
+            --table-border: #d0d7de;
+            --table-header-bg: #f6f8fa;
+            --table-row-alt-bg: #f6f8fa;
         }
 
         /* 다크 모드 */
@@ -97,6 +103,12 @@
                 --status-offline-bg: #2d2a1e;
                 --status-offline-border: #d29922;
                 --status-offline-text: #f2cc60;
+                --blockquote-bg: #161b22;
+                --blockquote-border: #58a6ff;
+                --blockquote-text: #c9d1d9;
+                --table-border: #30363d;
+                --table-header-bg: #161b22;
+                --table-row-alt-bg: #0f1720;
             }
         }
 


### PR DESCRIPTION
## Summary
- replace the inline blockquote renderer styling with a themed class
- add light and dark theme variables for blockquote and table colors
- update markdown styles to use the theme variables for blockquotes and tables

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692317aecff8832bb4b86ef7739742f6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Blockquote and table styling updated to use CSS variables for flexible theming.
  * Theme color variables added for light and dark modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->