### PR TITLE
Strip report structure markers before rendering markdown

### DIFF
--- a/web/components/content-viewer.js
+++ b/web/components/content-viewer.js
@@ -549,9 +549,13 @@ export class ContentViewer extends LitElement {
   }
 
   renderMarkdown(content) {
+    let cleanedContent = content;
     try {
+      // 보고서 구조 마커 제거
+      cleanedContent = this.cleanReportStructureMarkers(content);
+
       // Footnote 전처리
-      const processedContent = this.processFootnotes(content);
+      const processedContent = this.processFootnotes(cleanedContent);
       
       // Marked.js로 마크다운 파싱 (전역에서 사용 가능하다고 가정)
       const html = marked.parse(processedContent);
@@ -563,11 +567,18 @@ export class ContentViewer extends LitElement {
     } catch (error) {
       console.error('마크다운 렌더링 실패:', error);
       // 실패 시 기본 HTML 이스케이프
-      return content.replace(/&/g, '&amp;')
+      return cleanedContent.replace(/&/g, '&amp;')
                    .replace(/</g, '&lt;')
                    .replace(/>/g, '&gt;')
                    .replace(/\n/g, '<br>');
     }
+  }
+
+  cleanReportStructureMarkers(content) {
+    return content
+      .replace(/<REPORT_STRUCTURE_START>\s*/g, '')
+      .replace(/\s*<REPORT_STRUCTURE_END>/g, '')
+      .trim();
   }
 
   processFootnotes(content) {


### PR DESCRIPTION
## Summary
- remove report structure markers from summaries before markdown parsing so headings render properly
- ensure fallback sanitization also uses cleaned content

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69231b43efe8832b8c2cdca7ceefea34)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved content rendering consistency by ensuring unwanted markers are properly removed during processing. Enhanced error handling for markdown content to display cleaner output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->