### PR TITLE
Update Anthropic News RSS feed URL to community-maintained feed

### DIFF
--- a/backend/feeds.csv
+++ b/backend/feeds.csv
@@ -32,7 +32,7 @@ Spotify Engineering,https://engineering.atspotify.com/feed/,https://engineering.
 Y Combinator,https://feeds.feedburner.com/ycombinator,https://www.ycombinator.com/blog/,tech
 GeekNews,https://feeds.feedburner.com/geeknews-feed,https://news.hada.io/,tech
 Hacker News,https://hnrss.org/newest,https://news.ycombinator.com/news,tech
-Anthropic News (비공식),https://rsshub.app/anthropic/news,https://www.anthropic.com/news,tech
+Anthropic News,https://raw.githubusercontent.com/taobojlen/anthropic-rss-feed/main/anthropic_news_rss.xml,https://www.anthropic.com/news,tech
 Anthropic Engineering (비공식),https://rsshub.app/anthropic/engineering,https://www.anthropic.com/engineering,tech
 Anthropic Research (비공식),https://rsshub.app/anthropic/research,https://www.anthropic.com/research,tech
 Google Chrome Releases,http://feeds.feedburner.com/GoogleChromeReleases,https://chromereleases.googleblog.com/,tech


### PR DESCRIPTION
Replace rsshub.app-based Anthropic News feed with taobojlen's
GitHub-hosted RSS feed for more reliable updates.

https://claude.ai/code/session_01Hnb5ajGCvN6voapzUkYmky